### PR TITLE
Make tests pass

### DIFF
--- a/src/main/java/com/tinkerpop/gremlin/elastic/elasticservice/ElasticService.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/elasticservice/ElasticService.java
@@ -193,11 +193,12 @@ public class ElasticService {
 
 
         SearchRequestBuilder searchRequestBuilder = client.prepareSearch(result.getIndices())
-                .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),result.getFilter())).setFrom(0).setSize(100000); //TODO: retrive with scroll for efficiency
+                .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),result.getFilter())).setFrom(0).setSize(2000000); //TODO: retrive with scroll for efficiency
         if (labels != null && labels.length > 0 && labels[0] != null)
             searchRequestBuilder = searchRequestBuilder.setTypes(labels);
 
         SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();
+
         Iterable<SearchHit> hitsIterable = () -> searchResponse.getHits().iterator();
         Stream<SearchHit> hitStream = StreamSupport.stream(hitsIterable.spliterator(), false);
         timer("search").stop();

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/EdgeSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/EdgeSearchStep.java
@@ -13,12 +13,11 @@ import java.util.*;
  * Created by Eliran on 11/3/2015.
  */
 public class EdgeSearchStep extends ElasticSearchFlatMap<Vertex,Edge> {
-    ElasticService elasticService;
-    Direction direction;
-    List<String> edgeLabels;
+
+    private Direction direction;
+    private List<String> edgeLabels;
     public EdgeSearchStep(Traversal traversal,Direction direction,ElasticService elasticService, Optional<String> label,String... edgeLabels) {
-        super(traversal);
-        this.elasticService = elasticService;
+        super(traversal,elasticService);
         this.direction = direction;
         this.setFunction(traverser ->
                 getEdgesIterator(traverser) );
@@ -35,7 +34,7 @@ public class EdgeSearchStep extends ElasticSearchFlatMap<Vertex,Edge> {
 
     private Iterator<Edge> getEdgesIterator(Iterator<Vertex> vertexIterator) {
         vertexIterator.forEachRemaining(vertex -> this.addId(vertex.id()));
-        Iterator<Edge> edgeIterator = this.elasticService.searchEdges(FilterBuilderProvider.getFilter(this, direction),edgeLabels.toArray(new String[edgeLabels.size()]));
+        Iterator<Edge> edgeIterator = searchWithDups(Edge.class,direction,edgeLabels.toArray(new String[edgeLabels.size()]));
         return edgeIterator;
     }
 

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/EdgeSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/EdgeSearchStep.java
@@ -1,6 +1,7 @@
 package com.tinkerpop.gremlin.elastic.process.graph.traversal.sideEffect;
 
 import com.tinkerpop.gremlin.elastic.elasticservice.ElasticService;
+import com.tinkerpop.gremlin.elastic.structure.ElasticEdge;
 import com.tinkerpop.gremlin.process.Traversal;
 import com.tinkerpop.gremlin.process.util.TraversalHelper;
 import com.tinkerpop.gremlin.structure.Direction;
@@ -33,9 +34,57 @@ public class EdgeSearchStep extends ElasticSearchFlatMap<Vertex,Edge> {
     }
 
     private Iterator<Edge> getEdgesIterator(Iterator<Vertex> vertexIterator) {
-        vertexIterator.forEachRemaining(vertex -> this.addId(vertex.id()));
-        Iterator<Edge> edgeIterator = searchWithDups(Edge.class,direction,edgeLabels.toArray(new String[edgeLabels.size()]));
-        return edgeIterator;
+        List<String> originalVerticesIds = new ArrayList<String>();
+        HashMap<String,List<String>> vertexIdToEdgesResults = new HashMap<String,List<String>>();
+        vertexIterator.forEachRemaining(vertex -> {
+            this.addId(vertex.id());
+            String vertexIdString = vertex.id().toString();
+            originalVerticesIds.add(vertexIdString);
+
+        });
+        Iterator<Edge> edgeIterator = elasticService.searchEdges(FilterBuilderProvider.getFilter(this, direction), edgeLabels.toArray(new String[edgeLabels.size()]));
+        Map<String,Edge> edgeIdToEdge = new HashMap<String,Edge>();
+        edgeIterator.forEachRemaining(edge -> {
+            String edgeIdString = edge.id().toString();
+            edgeIdToEdge.put(edgeIdString,edge);
+            ElasticEdge elasticEdge = (ElasticEdge) edge;
+            List<String> vertexKeys = elasticEdge.getVertexId(direction);
+            for(String vertexKey : vertexKeys){
+                List<String> cacheList;
+                if(!vertexIdToEdgesResults.containsKey(vertexKey)){
+                    cacheList = new ArrayList<String>();
+                    vertexIdToEdgesResults.put(vertexKey,cacheList);
+                }
+                else cacheList = vertexIdToEdgesResults.get(vertexKey);
+                cacheList.add(edgeIdString);
+            }
+
+        });
+
+        return addJumpingPointsAndReturnCorrectedIterator(originalVerticesIds,vertexIdToEdgesResults,edgeIdToEdge);
+    }
+
+
+
+
+    private Iterator<Edge> addJumpingPointsAndReturnCorrectedIterator(List<String> inputIds,Map<String,List<String>> inputIdToResultSet,Map<String,Edge> edgeIdToEdge){
+
+        List<Edge> edges = new ArrayList<Edge>();
+        int counter = 0 ;
+        for(String fromVertexId : inputIds){
+            if(inputIdToResultSet.containsKey(fromVertexId)) {
+                List<String> toEdges = inputIdToResultSet.get(fromVertexId);
+                for (String edgeId : toEdges) {
+                    if(edgeIdToEdge.containsKey(edgeId)) {
+                        edges.add(edgeIdToEdge.get(edgeId));
+                        counter++;
+                    }
+                }
+            }
+            this.jumpingPoints.add(counter);
+        }
+        return edges.iterator();
+
     }
 
     @Override

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/EdgeSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/EdgeSearchStep.java
@@ -66,27 +66,6 @@ public class EdgeSearchStep extends ElasticSearchFlatMap<Vertex,Edge> {
 
 
 
-
-    private Iterator<Edge> addJumpingPointsAndReturnCorrectedIterator(List<String> inputIds,Map<String,List<String>> inputIdToResultSet,Map<String,Edge> edgeIdToEdge){
-
-        List<Edge> edges = new ArrayList<Edge>();
-        int counter = 0 ;
-        for(String fromVertexId : inputIds){
-            if(inputIdToResultSet.containsKey(fromVertexId)) {
-                List<String> toEdges = inputIdToResultSet.get(fromVertexId);
-                for (String edgeId : toEdges) {
-                    if(edgeIdToEdge.containsKey(edgeId)) {
-                        edges.add(edgeIdToEdge.get(edgeId));
-                        counter++;
-                    }
-                }
-            }
-            this.jumpingPoints.add(counter);
-        }
-        return edges.iterator();
-
-    }
-
     @Override
     public void setTypeLabel(String label){
         edgeLabels.add(label);

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticGraphStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticGraphStep.java
@@ -5,6 +5,7 @@ import com.tinkerpop.gremlin.elastic.structure.ElasticGraph;
 import com.tinkerpop.gremlin.process.Traversal;
 import com.tinkerpop.gremlin.process.graph.step.sideEffect.GraphStep;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
+import com.tinkerpop.gremlin.process.util.TraversalHelper;
 import com.tinkerpop.gremlin.structure.*;
 import org.elasticsearch.index.query.*;
 
@@ -18,6 +19,8 @@ public class ElasticGraphStep<E extends Element> extends GraphStep<E> implements
     BoolFilterBuilder boolFilterBuilder;
 
     public  List<HasContainer> hasContainers = new ArrayList<HasContainer>();
+    private String typelLabel;
+
     public ElasticGraphStep(final Traversal traversal, final ElasticGraph graph, final Class<E> returnClass, Optional<String> label, final Object... ids) {
         super(traversal, graph, returnClass, ids);
         this.idsExtended = new ArrayList<>();
@@ -30,15 +33,18 @@ public class ElasticGraphStep<E extends Element> extends GraphStep<E> implements
     }
 
     private Iterator<? extends Vertex> vertices() {
-        Iterator<Vertex> vertexIterator = elasticService.searchVertices(FilterBuilderProvider.getFilter(this), label());
+        Iterator<Vertex> vertexIterator = elasticService.searchVertices(FilterBuilderProvider.getFilter(this),this.typelLabel);
         return vertexIterator;
     }
 
     private Iterator<? extends Edge> edges() {
-        return elasticService.searchEdges(FilterBuilderProvider.getFilter(this), label());
+        return elasticService.searchEdges(FilterBuilderProvider.getFilter(this),typelLabel);
     }
 
-
+    @Override
+    public void setTypeLabel(String label){
+        this.typelLabel = label;
+    }
     private String label() {
         return this.getLabel().isPresent() ? this.getLabel().get() : null;
     }
@@ -70,6 +76,14 @@ public class ElasticGraphStep<E extends Element> extends GraphStep<E> implements
     @Override
     public void clearPredicates() {
         this.hasContainers = new ArrayList<HasContainer>();
+    }
+
+
+    @Override
+    public String toString(){
+        if(this.typelLabel!=null)
+            return TraversalHelper.makeStepString(this, this.returnClass.getSimpleName().toLowerCase(), Arrays.asList(this.typelLabel), this.getPredicates());
+        return TraversalHelper.makeStepString(this, this.returnClass.getSimpleName().toLowerCase(), this.getPredicates());
     }
 
 }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticGraphStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticGraphStep.java
@@ -2,13 +2,10 @@ package com.tinkerpop.gremlin.elastic.process.graph.traversal.sideEffect;
 
 import com.tinkerpop.gremlin.elastic.elasticservice.ElasticService;
 import com.tinkerpop.gremlin.elastic.structure.ElasticGraph;
-import com.tinkerpop.gremlin.elastic.traverser.B_O_PA_S_SE_SL_NC_Traverser;
 import com.tinkerpop.gremlin.process.Traversal;
 import com.tinkerpop.gremlin.process.TraverserGenerator;
 import com.tinkerpop.gremlin.process.graph.step.sideEffect.GraphStep;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
-import com.tinkerpop.gremlin.process.traverser.B_O_PA_S_SE_SL_Traverser;
-import com.tinkerpop.gremlin.process.traverser.B_O_P_PA_S_SE_SL_Traverser;
 import com.tinkerpop.gremlin.process.traverser.B_O_P_PA_S_SE_SL_TraverserGenerator;
 import com.tinkerpop.gremlin.process.util.TraversalHelper;
 import com.tinkerpop.gremlin.process.util.TraversalMetrics;

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticGraphStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticGraphStep.java
@@ -2,10 +2,16 @@ package com.tinkerpop.gremlin.elastic.process.graph.traversal.sideEffect;
 
 import com.tinkerpop.gremlin.elastic.elasticservice.ElasticService;
 import com.tinkerpop.gremlin.elastic.structure.ElasticGraph;
+import com.tinkerpop.gremlin.elastic.traverser.B_O_PA_S_SE_SL_NC_Traverser;
 import com.tinkerpop.gremlin.process.Traversal;
+import com.tinkerpop.gremlin.process.TraverserGenerator;
 import com.tinkerpop.gremlin.process.graph.step.sideEffect.GraphStep;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
+import com.tinkerpop.gremlin.process.traverser.B_O_PA_S_SE_SL_Traverser;
+import com.tinkerpop.gremlin.process.traverser.B_O_P_PA_S_SE_SL_Traverser;
+import com.tinkerpop.gremlin.process.traverser.B_O_P_PA_S_SE_SL_TraverserGenerator;
 import com.tinkerpop.gremlin.process.util.TraversalHelper;
+import com.tinkerpop.gremlin.process.util.TraversalMetrics;
 import com.tinkerpop.gremlin.structure.*;
 import org.elasticsearch.index.query.*;
 
@@ -39,6 +45,37 @@ public class ElasticGraphStep<E extends Element> extends GraphStep<E> implements
 
     private Iterator<? extends Edge> edges() {
         return elasticService.searchEdges(FilterBuilderProvider.getFilter(this),typelLabel);
+    }
+
+
+    @Override
+    public void generateTraversers(final TraverserGenerator traverserGenerator) {
+        if (PROFILING_ENABLED) TraversalMetrics.start(this);
+        try {
+            this.start = this.iteratorSupplier.get();
+            if (null != this.start) {
+
+                if (this.start instanceof Iterator) {
+                    List<E> newListForIterator = new ArrayList<>();
+                    Iterator<E> iter = (Iterator<E>) this.start;
+                    while(iter.hasNext()){
+                        E next = iter.next();
+
+                        //B_O_PA_S_SE_SL_NC_Traverser<E> eb_o_pa_s_se_sl_nc_traverser = new B_O_PA_S_SE_SL_NC_Traverser<>(next, this);
+                        this.starts.add(B_O_P_PA_S_SE_SL_TraverserGenerator.instance().generate(next,this,1l));
+                        newListForIterator.add(next);
+                    }
+                    this.start = newListForIterator.iterator();
+                    //this.starts.add(traverserGenerator.generateIterator((Iterator<E>) this.start, this, 1l));
+                } else {
+                    this.starts.add(traverserGenerator.generate((E) this.start, this, 1l));
+                }
+            }
+        } catch (final Exception e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        } finally {
+            if (PROFILING_ENABLED) TraversalMetrics.stop(this);
+        }
     }
 
     @Override

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
@@ -8,6 +8,7 @@ import com.tinkerpop.gremlin.process.graph.step.map.VertexStep;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
 import com.tinkerpop.gremlin.process.util.*;
 import com.tinkerpop.gremlin.structure.Direction;
+import com.tinkerpop.gremlin.structure.Edge;
 import com.tinkerpop.gremlin.structure.Element;
 import com.tinkerpop.gremlin.structure.Vertex;
 import org.elasticsearch.index.query.FilterBuilder;
@@ -123,6 +124,25 @@ public  class ElasticSearchFlatMap<S extends  Element, E extends Element > exten
     @Override
     public String toString() {
         return TraversalHelper.makeStepString(this,this.hasContainers);
+    }
+
+    protected Iterator<E> addJumpingPointsAndReturnCorrectedIterator(List<String> inputIds,Map<String,List<String>> inputIdToResultSet,Map<String,E> IdToElement){
+        List<E> elements = new ArrayList<E>();
+        int counter = 0 ;
+        for(String fromId : inputIds){
+            if(inputIdToResultSet.containsKey(fromId)) {
+                List<String> toIds = inputIdToResultSet.get(fromId);
+                for (String toId : toIds) {
+                    if(IdToElement.containsKey(toId)) {
+                        elements.add(IdToElement.get(toId));
+                        counter++;
+                    }
+                }
+            }
+            this.jumpingPoints.add(counter);
+        }
+        return elements.iterator();
+
     }
 
 }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
@@ -28,6 +28,7 @@ public  class ElasticSearchFlatMap<S extends  Element, E extends Element > exten
     protected ElasticService elasticService;
     Iterator< Traverser.Admin<S>> formerStepIterator;
     protected List<Integer> jumpingPoints;
+    protected String typeLabel;
 
     public ElasticSearchFlatMap(Traversal traversal,ElasticService elasticService) {
         super(traversal);
@@ -39,7 +40,7 @@ public  class ElasticSearchFlatMap<S extends  Element, E extends Element > exten
 
     @Override
     public void setTypeLabel(String label){
-        this.setLabel(label);
+        this.typeLabel = label;
     }
     @Override
     public Object[] getIds() {

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
@@ -97,14 +97,13 @@ public  class ElasticSearchFlatMap<S extends  Element, E extends Element > exten
             } else {
                 List<Traverser.Admin<S>> steps = new ArrayList<Traverser.Admin<S>>();
                 Traverser.Admin<S> first = this.starts.next();
-                Traverser.Admin<S> last = first;
                 steps.add(first);
                 List<S> elementsContainer = new ArrayList<S>();
-                elementsContainer.add(last.get());
+                elementsContainer.add(first.get());
                 while(this.starts.hasNext()){
-                    last = this.starts.next();
-                    elementsContainer.add(last.get());
-                    steps.add(last);
+                    Traverser.Admin<S> next = this.starts.next();
+                    elementsContainer.add(next.get());
+                    steps.add(next);
                 }
                 formerStepIterator = steps.iterator();
                 this.head = formerStepIterator.next();

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
@@ -2,6 +2,7 @@ package com.tinkerpop.gremlin.elastic.process.graph.traversal.sideEffect;
 
 import com.tinkerpop.gremlin.process.*;
 import com.tinkerpop.gremlin.process.graph.marker.Reversible;
+import com.tinkerpop.gremlin.process.graph.step.map.VertexStep;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
 import com.tinkerpop.gremlin.process.util.*;
 import com.tinkerpop.gremlin.structure.Element;
@@ -12,7 +13,7 @@ import java.util.function.Function;
 /**
  * Created by Eliran on 11/3/2015.
  */
-public class ElasticSearchFlatMap<S extends  Element, E extends Element > extends AbstractStep<S,E> implements Reversible,ElasticSearchStep {
+public  class ElasticSearchFlatMap<S extends  Element, E extends Element > extends AbstractStep<S,E> implements Reversible,ElasticSearchStep {
     private List<HasContainer> hasContainers;
     private List<Object> ids;
     private Function<Iterator<S>, Iterator<E>> function = null;
@@ -25,6 +26,10 @@ public class ElasticSearchFlatMap<S extends  Element, E extends Element > extend
         this.ids = new ArrayList<Object>();
     }
 
+    @Override
+    public void setTypeLabel(String label){
+        this.setLabel(label);
+    }
     @Override
     public Object[] getIds() {
         return this.ids.toArray();
@@ -71,14 +76,16 @@ public class ElasticSearchFlatMap<S extends  Element, E extends Element > extend
                 final Traverser<E> end = this.head.split(this.iterator.next(), this);
                 return end;
             } else {
-                Traverser.Admin<S> last = this.starts.next();
+
+                Traverser.Admin<S> first = this.starts.next();
+                Traverser.Admin<S> last = first;
                 List<S> elementsContainer = new ArrayList<>();
                 elementsContainer.add(last.get());
                 while(this.starts.hasNext()){
                     last = this.starts.next();
                     elementsContainer.add(last.get());
                 }
-                this.head = last;
+                this.head = first;
                 if (PROFILING_ENABLED) TraversalMetrics.start(this);
                 this.iterator = this.function.apply(elementsContainer.iterator());
                 if (PROFILING_ENABLED) TraversalMetrics.stop(this);
@@ -90,6 +97,11 @@ public class ElasticSearchFlatMap<S extends  Element, E extends Element > extend
     public void reset() {
         super.reset();
         this.iterator = Collections.emptyIterator();
+    }
+
+    @Override
+    public String toString() {
+        return TraversalHelper.makeStepString(this,this.hasContainers);
     }
 
 }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchFlatMap.java
@@ -114,45 +114,6 @@ public  class ElasticSearchFlatMap<S extends  Element, E extends Element > exten
         }
     }
 
-    protected <G extends Element> Iterator<G> searchWithDups(Class<G> returnClass ,Direction direction,String ... labels ){
-        //search and add duplicates
-        FilterBuilder filter = FilterBuilderProvider.getFilter(this,direction);
-        Object[] ids = this.getIds();
-        HashMap<String,Integer> idToOccurences = new HashMap<String,Integer>();
-        for (Object id : ids){
-            String stringId = id.toString();
-            if(idToOccurences.containsKey(stringId)){
-                Integer integer = idToOccurences.get(stringId);
-                idToOccurences.put(stringId,integer +1 );
-            }
-            else {
-                idToOccurences.put(stringId,1 );
-            }
-        }
-        Iterator<G> iterator;
-        if(returnClass.isAssignableFrom(Vertex.class))
-            iterator = (Iterator<G>) this.elasticService.searchVertices(filter,labels);
-        else iterator = (Iterator<G>) this.elasticService.searchEdges(filter, labels);
-        List<G> itemsWithDups = new ArrayList<G>();
-        while(iterator.hasNext()){
-            G element = iterator.next();
-            int numberOfDups = 1;
-            String idForDups;
-            if(returnClass.isAssignableFrom(Vertex.class)) idForDups = element.id().toString();
-            else {
-                ElasticEdge edge = (ElasticEdge) element;
-                idForDups =  edge.getVertexId(direction).get(0).toString();
-            }
-            if(idToOccurences.containsKey(idForDups))
-                numberOfDups = idToOccurences.get(idForDups);
-            for (int i=0 ; i<numberOfDups;i++){
-                itemsWithDups.add(element);
-            }
-        }
-
-        return itemsWithDups.iterator();
-    }
-
     @Override
     public void reset() {
         super.reset();

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/ElasticSearchStep.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface ElasticSearchStep {
     Object[] getIds();
     void addIds(Object[] ids);
-    void setLabel(String label);
+    void setTypeLabel(String label);
     void addPredicates(List<HasContainer> containerList);
     List<HasContainer> getPredicates();
     void addId(Object id);

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/FilterBuilderProvider.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/FilterBuilderProvider.java
@@ -33,6 +33,7 @@ public class FilterBuilderProvider {
                     case ("eq"):
                         if (has.key.equals("~label")) searchStep.setLabel(has.value.toString());
                         else if(has.key.equals("~id")) {
+                            searchStep.clearIds();
                             searchStep.addId(has.value);
                             ids = searchStep.getIds();
                         }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/FilterBuilderProvider.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/FilterBuilderProvider.java
@@ -31,7 +31,7 @@ public class FilterBuilderProvider {
                 String predicateString = has.predicate.toString();
                 switch (predicateString) {
                     case ("eq"):
-                        if (has.key.equals("~label")) searchStep.setLabel(has.value.toString());
+                        if (has.key.equals("~label")) searchStep.setTypeLabel(has.value.toString());
                         else if(has.key.equals("~id")) {
                             searchStep.clearIds();
                             searchStep.addId(has.value);

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/VertexSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/VertexSearchStep.java
@@ -71,9 +71,8 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
         this.clearIds();
         this.addIds(vertexIds.toArray());
         this.addPredicates(predicates);
-
-        Iterator<Vertex> vertexIterator = this.elasticService.searchVertices(FilterBuilderProvider.getFilter(this));
-        return prepareAndAddJumpingPointsAndReturnCorrectedIterator(originalVertexIterator,idToResultsIds,vertexIterator);
+        Iterator<Vertex> vertexIterator = this.elasticService.searchVertices(FilterBuilderProvider.getFilter(this),this.typeLabel);
+        return prepareAndAddJumpingPointsAndReturnCorrectedIterator(originalVertexIterator, idToResultsIds, vertexIterator);
     }
 
     private Map<String,List<String>> searchEdgesAndAddIds(Direction direction, List<Object> vertexIds, Map<String,List<String>> vertexToResultVertices) {
@@ -106,8 +105,8 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
             originalEdgeIds.add(edgeId);
         }
 
-        Iterator<Vertex> vertexIterator = this.elasticService.searchVertices(FilterBuilderProvider.getFilter(this));
-        return prepareAndAddJumpingPointsAndReturnCorrectedIterator(originalEdgeIds,edgeIdToResultsIds,vertexIterator);
+        Iterator<Vertex> vertexIterator = this.elasticService.searchVertices(FilterBuilderProvider.getFilter(this),this.typeLabel);
+        return prepareAndAddJumpingPointsAndReturnCorrectedIterator(originalEdgeIds, edgeIdToResultsIds, vertexIterator);
     }
 
 

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/VertexSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/VertexSearchStep.java
@@ -4,6 +4,7 @@ import com.tinkerpop.gremlin.elastic.elasticservice.ElasticService;
 import com.tinkerpop.gremlin.elastic.structure.ElasticEdge;
 import com.tinkerpop.gremlin.process.Traversal;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
+import com.tinkerpop.gremlin.process.util.TraversalHelper;
 import com.tinkerpop.gremlin.structure.Direction;
 import com.tinkerpop.gremlin.structure.Edge;
 import com.tinkerpop.gremlin.structure.Vertex;
@@ -11,10 +12,7 @@ import com.tinkerpop.gremlin.structure.Element;
 import org.elasticsearch.index.query.BoolFilterBuilder;
 import org.elasticsearch.index.query.FilterBuilders;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Created by Eliran on 11/3/2015.
@@ -63,6 +61,8 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
             Iterator<Edge> edgeIterator = this.elasticService.searchEdges(FilterBuilderProvider.getFilter(this, this.direction), edgeLabels);
             edgeIterator.forEachRemaining(edge -> vertexIds.addAll(((ElasticEdge) edge).getVertexId(this.direction.opposite())));
         }
+
+        if(vertexIds.isEmpty()) return (new ArrayList<Vertex>()).iterator();
         //remove ids from edges query and put new ones
         this.clearIds();
         this.addIds(vertexIds.toArray());
@@ -78,5 +78,13 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
         }
         String label = this.getLabel().isPresent()?  this.label.get() : null;
         return elasticService.searchVertices(FilterBuilderProvider.getFilter(this),label);
+    }
+
+
+    @Override
+    public String toString(){
+        if(this.edgeLabels!=null && this.edgeLabels.length > 0)
+            return TraversalHelper.makeStepString(this, this.direction, this.stepClass.getSimpleName().toLowerCase(), Arrays.asList(this.edgeLabels),this.getPredicates());
+        return TraversalHelper.makeStepString(this, this.direction, this.stepClass.getSimpleName().toLowerCase(),this.getPredicates());
     }
 }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/VertexSearchStep.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/sideEffect/VertexSearchStep.java
@@ -3,6 +3,7 @@ package com.tinkerpop.gremlin.elastic.process.graph.traversal.sideEffect;
 import com.tinkerpop.gremlin.elastic.elasticservice.ElasticService;
 import com.tinkerpop.gremlin.elastic.structure.ElasticEdge;
 import com.tinkerpop.gremlin.process.Traversal;
+import com.tinkerpop.gremlin.process.graph.step.map.VertexStep;
 import com.tinkerpop.gremlin.process.graph.util.HasContainer;
 import com.tinkerpop.gremlin.process.util.TraversalHelper;
 import com.tinkerpop.gremlin.structure.Direction;
@@ -47,17 +48,22 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
     }
 
     private Iterator<Vertex> getVerticesFromVertex(Iterator<E> elementIterator) {
-        elementIterator.forEachRemaining(vertex -> this.addId(vertex.id()));
+        List<String> originalVertexIterator = new ArrayList<>();
+        elementIterator.forEachRemaining(vertex -> {
+            this.addId(vertex.id());
+            originalVertexIterator.add(vertex.id().toString());
+        });
         //perdicates belongs to vertices query
         List<HasContainer> predicates = this.getPredicates();
         this.clearPredicates();
         List<Object> vertexIds = new ArrayList<Object>();
+        Map<String,List<String>> idToResultsIds = new HashMap<String,List<String>>();
         if(this.direction == Direction.BOTH){
-            searchEdgesAndAddIds(Direction.IN,vertexIds);
-            searchEdgesAndAddIds(Direction.OUT,vertexIds);
+            searchEdgesAndAddIds(Direction.IN,vertexIds,idToResultsIds);
+            idToResultsIds =  searchEdgesAndAddIds(Direction.OUT,vertexIds,idToResultsIds);
         }
         else {
-            searchEdgesAndAddIds(this.direction,vertexIds);
+            idToResultsIds =  searchEdgesAndAddIds(this.direction,vertexIds,idToResultsIds);
         }
 
         if(vertexIds.isEmpty()) return (new ArrayList<Vertex>()).iterator();
@@ -66,22 +72,49 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
         this.addIds(vertexIds.toArray());
         this.addPredicates(predicates);
 
-        return searchWithDups(Vertex.class,null);
+        FilterBuilder filter = FilterBuilderProvider.getFilter(this);
+        Object[] ids = this.getIds();
+        //Iterator<Vertex> vertexIterator = searchWithDups(Vertex.class, null);
 
+
+        Iterator<Vertex> vertexIterator = this.elasticService.searchVertices(filter);
+        return addJumpingPointsAndReturnCorrectedIterator(originalVertexIterator,idToResultsIds,vertexIterator);
     }
 
-    private void searchEdgesAndAddIds(Direction direction, List<Object> vertexIds) {
-        Iterator<Edge> edgeIterator = searchWithDups(Edge.class, direction, edgeLabels);
-        edgeIterator.forEachRemaining(edge -> vertexIds.addAll(((ElasticEdge) edge).getVertexId(direction.opposite())));
+    private Map<String,List<String>> searchEdgesAndAddIds(Direction direction, List<Object> vertexIds, Map<String,List<String>> vertexToResultVertices) {
+        //Iterator<Edge> edgeIterator = searchWithDups(Edge.class, direction, edgeLabels);
+        Iterator<Edge> edgeIterator = this.elasticService.searchEdges(FilterBuilderProvider.getFilter(this,direction),this.edgeLabels );
+        edgeIterator.forEachRemaining(edge -> {
+            Object idOposite = ((ElasticEdge) edge).getVertexId(direction.opposite()).get(0);
+            String idOpositeString = idOposite.toString();
+            String idNormal = ((ElasticEdge) edge).getVertexId(direction).get(0).toString();
+            vertexIds.add(idOposite);
+            List<String> cacheList;
+            if(!vertexToResultVertices.containsKey(idNormal)){
+                cacheList = new ArrayList<String>();
+                vertexToResultVertices.put(idNormal,cacheList);
+            }
+            else cacheList = vertexToResultVertices.get(idNormal);
+            cacheList.add(idOpositeString);
+        });
+        return vertexToResultVertices;
     }
 
     private Iterator<Vertex> getVerticesFromEdges(Iterator<E> elementIterator) {
+        Map<String,List<String>> edgeIdToResultsIds =  new HashMap<String,List<String>>();
+        List<String> originalEdgeIds = new ArrayList<String>();
         while(elementIterator.hasNext()){
             ElasticEdge edge = (ElasticEdge) elementIterator.next();
-            this.addIds(edge.getVertexId(direction).toArray());
+            List vertexIds = edge.getVertexId(direction);
+            this.addIds(vertexIds.toArray());
+            String edgeId = edge.id().toString();
+            edgeIdToResultsIds.put(edgeId, vertexIds);
+            originalEdgeIds.add(edgeId);
         }
-        String label = this.getLabel().isPresent()?  this.label.get() : null;
-        return searchWithDups(Vertex.class,null,label);
+
+        //String label = this.getLabel().isPresent()?  this.label.get() : null;
+        Iterator<Vertex> vertexIterator = this.elasticService.searchVertices(FilterBuilderProvider.getFilter(this));
+        return addJumpingPointsAndReturnCorrectedIterator(originalEdgeIds,edgeIdToResultsIds,vertexIterator);
     }
 
 
@@ -92,4 +125,31 @@ public class VertexSearchStep<E extends Element> extends ElasticSearchFlatMap<E,
             return TraversalHelper.makeStepString(this, this.direction, this.stepClass.getSimpleName().toLowerCase(), Arrays.asList(this.edgeLabels),this.getPredicates());
         return TraversalHelper.makeStepString(this, this.direction, this.stepClass.getSimpleName().toLowerCase(),this.getPredicates());
     }
+
+
+
+    private Iterator<Vertex> addJumpingPointsAndReturnCorrectedIterator(List<String> inputIds,Map<String,List<String>> inputIdToResultSet,Iterator<Vertex> resultSetFromSearch){
+        HashMap<String,Vertex> idToVertex  = new HashMap<String,Vertex>();
+        while(resultSetFromSearch.hasNext()){
+            Vertex v = resultSetFromSearch.next();
+            idToVertex.put(v.id().toString(),v);
+        }
+        List<Vertex> vertices = new ArrayList<Vertex>();
+        int counter = 0 ;
+        for(String fromVertexId : inputIds){
+            if(inputIdToResultSet.containsKey(fromVertexId)) {
+                List<String> toVertices = inputIdToResultSet.get(fromVertexId);
+                for (String vertexId : toVertices) {
+                    if(idToVertex.containsKey(vertexId)) {
+                        vertices.add(idToVertex.get(vertexId));
+                        counter++;
+                    }
+                }
+            }
+            this.jumpingPoints.add(counter);
+        }
+        return vertices.iterator();
+
+    }
+
 }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/strategy/ElasticGraphStepStrategy.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/strategy/ElasticGraphStepStrategy.java
@@ -52,8 +52,13 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
                     traversal.removeStep(currentStep);
 
                 } else if (currentStep instanceof VertexStep) {
-                    addPredicates = true;
                     VertexStep<?> originalVertexStep = (VertexStep) currentStep;
+//                    if(originalVertexStep.getLabel().isPresent()){
+//                        addPredicates = false;
+//                        currentStep = currentStep.getNextStep();
+//                        continue;
+//                    }
+                    addPredicates = true;
                     Class<? extends Element> returnClassOfVertexStep = originalVertexStep.getReturnClass();
                     ElasticSearchStep newSearchStep;
                     if(Vertex.class.isAssignableFrom(returnClassOfVertexStep)){
@@ -67,8 +72,13 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
 
                 }
                 else if (currentStep instanceof EdgeVertexStep){
-                    addPredicates = true;
                     EdgeVertexStep originalEdgeStep = (EdgeVertexStep) currentStep;
+//                    if(originalEdgeStep.getLabel().isPresent()){
+//                        addPredicates = false;
+//                        currentStep = currentStep.getNextStep();
+//                        continue;
+//                    }
+                    addPredicates = true;
                     ElasticSearchStep newSearchStep = new VertexSearchStep<>(originalEdgeStep.getTraversal(),originalEdgeStep.getDirection(),graph.elasticService, Edge.class,originalEdgeStep.getLabel());
                     TraversalHelper.replaceStep(currentStep, (Step) newSearchStep, traversal);
                     lastElasticSearchStep = newSearchStep;

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/strategy/ElasticGraphStepStrategy.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/strategy/ElasticGraphStepStrategy.java
@@ -26,6 +26,7 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
         return INSTANCE;
     }
 
+
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal, final TraversalEngine engine) {
         if (engine.equals(TraversalEngine.COMPUTER)) return;
@@ -38,10 +39,11 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
             TraversalHelper.replaceStep(startStep, (Step) elasticGraphStep, traversal);
             ElasticSearchStep lastElasticSearchStep = elasticGraphStep;
             Step<?, ?> currentStep = elasticGraphStep.getNextStep();
+            boolean addPredicates = true;
             while (true) {
                 if (currentStep instanceof HasContainerHolder) {
 
-                    lastElasticSearchStep.addPredicates(((HasContainerHolder) currentStep).getHasContainers());
+                    if(addPredicates) lastElasticSearchStep.addPredicates(((HasContainerHolder) currentStep).getHasContainers());
                     if (currentStep.getLabel().isPresent()) {
                         final IdentityStep identityStep = new IdentityStep<>(traversal);
                         identityStep.setLabel(currentStep.getLabel().get());
@@ -50,7 +52,7 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
                     traversal.removeStep(currentStep);
 
                 } else if (currentStep instanceof VertexStep) {
-
+                    addPredicates = true;
                     VertexStep<?> originalVertexStep = (VertexStep) currentStep;
                     Class<? extends Element> returnClassOfVertexStep = originalVertexStep.getReturnClass();
                     ElasticSearchStep newSearchStep;
@@ -65,7 +67,7 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
 
                 }
                 else if (currentStep instanceof EdgeVertexStep){
-
+                    addPredicates = true;
                     EdgeVertexStep originalEdgeStep = (EdgeVertexStep) currentStep;
                     ElasticSearchStep newSearchStep = new VertexSearchStep<>(originalEdgeStep.getTraversal(),originalEdgeStep.getDirection(),graph.elasticService, Edge.class,originalEdgeStep.getLabel());
                     TraversalHelper.replaceStep(currentStep, (Step) newSearchStep, traversal);
@@ -76,6 +78,8 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
                     break;
                 } else {
                     //continue on other Steps.
+                    addPredicates = false;
+
                 }
 
                 currentStep = currentStep.getNextStep();

--- a/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/strategy/ElasticGraphStepStrategy.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/process/graph/traversal/strategy/ElasticGraphStepStrategy.java
@@ -53,11 +53,6 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
 
                 } else if (currentStep instanceof VertexStep) {
                     VertexStep<?> originalVertexStep = (VertexStep) currentStep;
-//                    if(originalVertexStep.getLabel().isPresent()){
-//                        addPredicates = false;
-//                        currentStep = currentStep.getNextStep();
-//                        continue;
-//                    }
                     addPredicates = true;
                     Class<? extends Element> returnClassOfVertexStep = originalVertexStep.getReturnClass();
                     ElasticSearchStep newSearchStep;
@@ -73,11 +68,6 @@ public class ElasticGraphStepStrategy extends AbstractTraversalStrategy {
                 }
                 else if (currentStep instanceof EdgeVertexStep){
                     EdgeVertexStep originalEdgeStep = (EdgeVertexStep) currentStep;
-//                    if(originalEdgeStep.getLabel().isPresent()){
-//                        addPredicates = false;
-//                        currentStep = currentStep.getNextStep();
-//                        continue;
-//                    }
                     addPredicates = true;
                     ElasticSearchStep newSearchStep = new VertexSearchStep<>(originalEdgeStep.getTraversal(),originalEdgeStep.getDirection(),graph.elasticService, Edge.class,originalEdgeStep.getLabel());
                     TraversalHelper.replaceStep(currentStep, (Step) newSearchStep, traversal);


### PR DESCRIPTION
supports "as" steps
explanation how:
We weren't able to support it because we did one search per VertexStep/EdgeStep
now we are ordering the results and maintaining jump list
example for modern graph:
if you ask for:
g.V("1","6").as("a").out().as("b")
what we did:
1st search brings v1,v6
2nd brings e7,e9,e8,e12
3rd brings v3,v2,v4
and just returned the results (v3,v2,v4)
what we do now:
1st search brings v1,v6 and open traverser for each one of them 
2nd search brings e7,e9,e8,e12 .
3rd bring v3,v2,v4 
now creates a map (using the edges from former search) { v1 -> {v3,v2,v4} , v6->{v3}}
create jump list - on which index we jump to next former vertex(v1 or v6)
the jump list will be (3,4)
and order the vertices and return them (v3,v2,v4,v3)

the modern graph:
![image](https://cloud.githubusercontent.com/assets/2933669/6652716/dd151008-ca80-11e4-9b2c-26e03e484e5d.png)
