### PR TITLE
Lazy vertices

### DIFF
--- a/src/main/java/com/tinkerpop/gremlin/elastic/elasticservice/LazyGetter.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/elasticservice/LazyGetter.java
@@ -1,0 +1,44 @@
+package com.tinkerpop.gremlin.elastic.elasticservice;
+
+import com.tinkerpop.gremlin.elastic.structure.ElasticVertex;
+import org.elasticsearch.action.get.*;
+
+import java.util.*;
+
+public class LazyGetter {
+    private static final int MAX_LAZY_GET = 1000;
+    private boolean executed = false;
+    private MultiGetRequest multiGetRequest = new MultiGetRequest();
+    private HashMap<String, ElasticVertex> lazyGetters = new HashMap();
+    private ElasticService es;
+
+    public LazyGetter(ElasticService es) {
+        this.es = es;
+    }
+
+    public Boolean canRegister() {
+        return !executed && multiGetRequest.getItems().size() < MAX_LAZY_GET;
+    }
+
+    public void register(ElasticVertex v) {
+        SchemaProvider.Result schemaProviderResult = es.schemaProvider.getIndex(v.label(), v.id(), ElasticService.ElementType.vertex, null);
+        multiGetRequest.add(schemaProviderResult.getIndex(), v.label(), v.id().toString()); //TODO: add routing..?
+        lazyGetters.put(v.id().toString(), v);
+    }
+
+    public void execute() {
+        if (executed) return;
+
+        MultiGetResponse multiGetItemResponses = es.client.multiGet(multiGetRequest).actionGet();
+        multiGetItemResponses.forEach(response -> {
+            Map<String, Object> source = response.getResponse().getSource();
+            ElasticVertex v = lazyGetters.get(response.getId());
+            source.entrySet().forEach((field) -> v.addPropertyLocal(field.getKey(), field.getValue()));
+        });
+
+        executed = true;
+        multiGetRequest = null;
+        lazyGetters = null;
+        es = null;
+    }
+}

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticEdge.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticEdge.java
@@ -50,8 +50,8 @@ public class ElasticEdge extends ElasticElement implements Edge, Edge.Iterators 
     @Override
     public void remove() {
         checkRemoved();
-        this.removed = true;
         elasticService.deleteElement(this);
+        this.removed = true;
     }
 
     @Override

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticEdge.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticEdge.java
@@ -29,11 +29,8 @@ public class ElasticEdge extends ElasticElement implements Edge, Edge.Iterators 
     }
 
     @Override
-    public Property addPropertyLocal(String key, Object value) {
-        if (!shouldAddProperty(key)) return Property.empty();
-        ElasticProperty vertexProperty = new ElasticProperty(this, key, value);
-        properties.put(key, vertexProperty);
-        return vertexProperty;
+    public Property createProperty(String key, Object value) {
+        return new ElasticProperty(this, key, value);
     }
 
     @Override
@@ -72,7 +69,13 @@ public class ElasticEdge extends ElasticElement implements Edge, Edge.Iterators 
     @Override
     public Iterator<Vertex> vertexIterator(final Direction direction) {
         checkRemoved();
-        return elasticService.getVertices(null,null,getVertexId(direction).toArray());
+        ArrayList vertices = new ArrayList();
+        //return elasticService.getVertices(null,null,getVertexId(direction).toArray());
+        if(direction.equals(Direction.OUT) || direction.equals(Direction.BOTH))
+            vertices.add(new ElasticVertex(outId,outLabel,null,graph,true));
+        if(direction.equals(Direction.IN) || direction.equals(Direction.BOTH))
+            vertices.add(new ElasticVertex(inId,inLabel,null,graph,true));
+        return vertices.iterator();
     }
 
     public List getVertexId(Direction direction) {

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticElement.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticElement.java
@@ -16,7 +16,23 @@ public abstract class ElasticElement implements Element, Element.Iterators {
         this.graph = graph;
         this.id = id;
         this.label = label;
-        if (keyValues != null) addPropertiesLocal(keyValues);
+        if (keyValues != null) {
+            for (int i = 0; i < keyValues.length; i = i + 2) {
+                String key = keyValues[i].toString();
+                Object value = keyValues[i + 1];
+                addPropertyLocal(key, value);
+            }
+        }
+    }
+
+    public Property addPropertyLocal(String key, Object value) {
+        checkRemoved();
+        if (shouldAddProperty(key)) {
+            Property property = createProperty(key, value);
+            properties.put(key, property);
+            return property;
+        }
+        return null;
     }
 
     @Override
@@ -71,15 +87,7 @@ public abstract class ElasticElement implements Element, Element.Iterators {
         graph.elasticService.removeProperty(this, property.key());
     }
 
-    private void addPropertiesLocal(Object[] keyValues) {
-        for (int i = 0; i < keyValues.length; i = i + 2) {
-            String key = keyValues[i].toString();
-            Object value = keyValues[i + 1];
-            this.addPropertyLocal(key, value);
-        }
-    }
-
-    public abstract Property addPropertyLocal(String key, Object value);
+    public abstract Property createProperty(String key, Object value);
 
     protected boolean shouldAddProperty(String key) {
         return key != "label" && key != "id";

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticGraph.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticGraph.java
@@ -98,7 +98,7 @@ public class ElasticGraph implements Graph, Graph.Iterators {
         final String label = ElementHelper.getLabelValue(keyValues).orElse(Vertex.DEFAULT_LABEL);
         try {
             Object id = elasticService.addElement(label, idValue, ElasticService.ElementType.vertex, keyValues);
-            return new ElasticVertex(id, label, keyValues, this);
+            return new ElasticVertex(id, label, keyValues, this, false);
         } catch (DocumentAlreadyExistsException ex) {
             throw Graph.Exceptions.vertexWithIdAlreadyExists(idValue);
         }

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticVertex.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticVertex.java
@@ -8,20 +8,18 @@ import org.elasticsearch.index.query.*;
 import java.util.*;
 
 public class ElasticVertex extends ElasticElement implements Vertex, Vertex.Iterators {
+    private ElasticService.LazyGetter lazyGetter;
     private ElasticService elasticService;
 
-    public ElasticVertex(final Object id, final String label, Object[] keyValues, ElasticGraph graph) {
+    public ElasticVertex(final Object id, final String label, Object[] keyValues, ElasticGraph graph, Boolean lazy) {
         super(id, label, graph, keyValues);
         elasticService = graph.elasticService;
+        if(lazy) this.lazyGetter = graph.elasticService.registerLazyVertex(this);
     }
 
     @Override
-    public Property addPropertyLocal(String key, Object value) {
-        checkRemoved();
-        if (!shouldAddProperty(key)) return Property.empty();
-        ElasticVertexProperty vertexProperty = new ElasticVertexProperty(this, key, value);
-        properties.put(key, vertexProperty);
-        return vertexProperty;
+    public Property createProperty(String key, Object value) {
+        return new ElasticVertexProperty(this, key, value);
     }
 
     @Override
@@ -35,7 +33,6 @@ public class ElasticVertex extends ElasticElement implements Vertex, Vertex.Iter
         checkRemoved();
         ElementHelper.validateProperty(key, value);
         ElasticVertexProperty vertexProperty = (ElasticVertexProperty) addPropertyLocal(key, value);
-        properties.put(key, vertexProperty);
         elasticService.addProperty(this, key, value);
         return vertexProperty;
     }
@@ -43,6 +40,7 @@ public class ElasticVertex extends ElasticElement implements Vertex, Vertex.Iter
     @Override
     public <V> VertexProperty<V> property(final String key) {
         checkRemoved();
+        if(lazyGetter != null) lazyGetter.execute();
         if (this.properties.containsKey(key)) {
             return (VertexProperty<V>) this.properties.get(key);
         } else return VertexProperty.<V>empty();
@@ -76,6 +74,7 @@ public class ElasticVertex extends ElasticElement implements Vertex, Vertex.Iter
     @Override
     public <V> Iterator<VertexProperty<V>> propertyIterator(final String... propertyKeys) {
         checkRemoved();
+        if(lazyGetter != null) lazyGetter.execute();
         return innerPropertyIterator(propertyKeys);
     }
 

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticVertex.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticVertex.java
@@ -56,9 +56,9 @@ public class ElasticVertex extends ElasticElement implements Vertex, Vertex.Iter
     @Override
     public void remove() {
         checkRemoved();
-        this.removed = true;
         elasticService.deleteElement(this);
         elasticService.deleteElements((Iterator) edgeIterator(Direction.BOTH));
+        this.removed = true;
     }
 
     @Override

--- a/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticVertex.java
+++ b/src/main/java/com/tinkerpop/gremlin/elastic/structure/ElasticVertex.java
@@ -1,6 +1,6 @@
 package com.tinkerpop.gremlin.elastic.structure;
 
-import com.tinkerpop.gremlin.elastic.elasticservice.ElasticService;
+import com.tinkerpop.gremlin.elastic.elasticservice.*;
 import com.tinkerpop.gremlin.structure.*;
 import com.tinkerpop.gremlin.structure.util.*;
 import org.elasticsearch.index.query.*;
@@ -8,13 +8,16 @@ import org.elasticsearch.index.query.*;
 import java.util.*;
 
 public class ElasticVertex extends ElasticElement implements Vertex, Vertex.Iterators {
-    private ElasticService.LazyGetter lazyGetter;
+    private LazyGetter lazyGetter;
     private ElasticService elasticService;
 
     public ElasticVertex(final Object id, final String label, Object[] keyValues, ElasticGraph graph, Boolean lazy) {
         super(id, label, graph, keyValues);
         elasticService = graph.elasticService;
-        if(lazy) this.lazyGetter = graph.elasticService.registerLazyVertex(this);
+        if(lazy) {
+            this.lazyGetter = graph.elasticService.getLazyGetter();
+            lazyGetter.register(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
support creating Vertex object without querying ES, given an id and label. when "asked" for the vertex's properties, a MultiGet request is created with all the lazy vertices created up to that point.
use lazy vertices in elasticEdge.vertexIterator() (fix issue #27 ).
Lazy vertices might also help in future optimizations, like #23.
