### PR TITLE
Adjust pom so that it no longer uses TinkerPop as parent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,36 +2,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.tinkerpop</groupId>
-        <artifactId>tinkerpop</artifactId>
-        <version>3.0.0.M9-incubating-rc2</version>
-    </parent>
+    <groupId>elastic-gremlin</groupId>
     <artifactId>elastic-gremlin</artifactId>
+    <version>0.1.0</version>
     <properties>
+        <tinkerpop.version>3.0.0.M9-incubating-rc2</tinkerpop.version>
         <elasticsearch.version>1.5.2</elasticsearch.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-core</artifactId>
-            <version>${project.version}</version>
+            <version>${tinkerpop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-groovy</artifactId>
-            <version>${project.version}</version>
+            <version>${tinkerpop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-test</artifactId>
-            <version>${project.version}</version>
+            <version>${tinkerpop.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-groovy-test</artifactId>
-            <version>${project.version}</version>
+            <version>${tinkerpop.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -57,12 +55,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.stephenc.eaio-uuid</groupId>
             <artifactId>uuid</artifactId>
             <version>3.4.0</version>
@@ -74,7 +66,41 @@
         </dependency>
     </dependencies>
     <build>
+        <directory>${basedir}/target</directory>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-all</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <DependencyConvergence/>
+                                <requireJavaVersion>
+                                    <version>[1.8.0-40,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
I wanted to try out your build against against the test-suite as you have an interesting set of `Features` enabled.  I made some changes to your pom.xml in the process of figuring out how to build the project.  I didn't think you wanted to have the pom use TinkerPop as a parent because that brings with it a lot of extra stuff like the rat plugin, the apache oss parent pom config, forces you to have the same version as the TinkerPop version (which might not be desirable if you have to issue a fix), etc.  

Anyway, that was the reasoning for the change.  I suspect that you would eventually go this direction as you continued to develop `elastic-gremlin` so hopefully this PR is helpful in some small way.