### PR TITLE
Refactored LazyGetter

### DIFF
--- a/src/main/java/org/elasticgremlin/elasticsearch/LazyGetter.java
+++ b/src/main/java/org/elasticgremlin/elasticsearch/LazyGetter.java
@@ -1,39 +1,38 @@
 package org.elasticgremlin.elasticsearch;
 
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.elasticgremlin.structure.BaseElement;
+import org.elasticgremlin.structure.BaseVertex;
 import org.elasticsearch.action.get.*;
 import org.elasticsearch.client.Client;
 
 import java.util.*;
-import java.util.function.Consumer;
 
 public class LazyGetter {
-
-    public interface LazyConsumer extends Element {
-        void applyLazyFields(MultiGetItemResponse response);
-    }
 
     private static final int MAX_LAZY_GET = 1000;
     private Client client;
     private boolean executed = false;
     private MultiGetRequest multiGetRequest = new MultiGetRequest();
-    private HashMap<String, List<LazyConsumer>> lazyGetters = new HashMap();
-    private Consumer<List<Vertex>> siblingsFunc;
+    private HashMap<String, List<BaseVertex>> lazyVertices = new HashMap();
+    private List<Vertex> siblings = new ArrayList<>();
 
-    public LazyGetter(Client client, Consumer<List<Vertex>> siblingsFunc) {
+    public LazyGetter(Client client) {
         this.client = client;
-        this.siblingsFunc = siblingsFunc;
     }
 
     public Boolean canRegister() {
         return !executed && multiGetRequest.getItems().size() < MAX_LAZY_GET;
     }
 
-    public void register(LazyConsumer v, String indexName) {
+    public void register(BaseVertex v, String indexName) {
         multiGetRequest.add(indexName, null, v.id().toString()); //TODO: add routing..?
-        putOrAddToList(lazyGetters, v.id().toString(), v);
+        putOrAddToList(lazyVertices, v.id().toString(), v);
+        addSiblings(v);
+    }
+
+    protected void addSiblings(BaseVertex v) {
+        siblings.add(v);
+        v.setSiblings(siblings);
     }
 
     protected void putOrAddToList(Map map, Object key, Object value) {
@@ -52,24 +51,14 @@ public class LazyGetter {
         multiGetItemResponses.forEach(response -> {
             GetResponse getResponse = response.getResponse();
             if (getResponse == null || !getResponse.isExists()) return;
-            List<LazyConsumer> vertices = lazyGetters.get(response.getId());
+            List<BaseVertex> vertices = lazyVertices.get(response.getId());
             if (vertices == null) return;
             vertices.forEach(vertex -> vertex.applyLazyFields(response));
         });
 
-        // Apply siblings
-        List<Vertex> allVertices = new ArrayList<>();
-        lazyGetters.forEach((id, vertices) -> {
-            vertices.forEach(lazyConsumer -> {
-                if (!Vertex.class.isAssignableFrom(lazyConsumer.getClass())) return;
-                allVertices.add((Vertex) lazyConsumer);
-            });
-        });
-        siblingsFunc.accept(allVertices);
-
         executed = true;
         multiGetRequest = null;
-        lazyGetters = null;
+        lazyVertices = null;
         client = null;
     }
 }

--- a/src/main/java/org/elasticgremlin/process/optimize/ElasticOptimizationStrategy.java
+++ b/src/main/java/org/elasticgremlin/process/optimize/ElasticOptimizationStrategy.java
@@ -5,11 +5,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GraphStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.*;
 import org.elasticgremlin.queryhandler.Predicates;
 import org.elasticgremlin.structure.ElasticGraph;
 
@@ -51,10 +49,10 @@ public class ElasticOptimizationStrategy extends AbstractTraversalStrategy<Trave
             if(nextStep instanceof HasContainerHolder) {
                 HasContainerHolder hasContainerHolder = (HasContainerHolder) nextStep;
                 boolean skip = false;
-                for(HasContainer has : hasContainerHolder.getHasContainers())
+                /*for(HasContainer has : hasContainerHolder.getHasContainers())
                     if(has.getPredicate().getTraversals().size() > 0)
                         skip = true;
-
+                */
                 if(!skip) {
                     hasContainerHolder.getHasContainers().forEach(predicates.hasContainers::add);
                     collectLabels(predicates, nextStep);

--- a/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarHandler.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarHandler.java
@@ -149,7 +149,7 @@ public class StarHandler implements VertexHandler, EdgeHandler {
 
     private LazyGetter getLazyGetter() {
         if (defaultLazyGetter == null || !defaultLazyGetter.canRegister()) {
-            defaultLazyGetter = new LazyGetter(client, StarVertex::setVertexAndExternalSiblings);
+            defaultLazyGetter = new LazyGetter(client);
         }
         return defaultLazyGetter;
     }
@@ -157,7 +157,7 @@ public class StarHandler implements VertexHandler, EdgeHandler {
     private LazyGetter getLazyGetter(Direction direction) {
         LazyGetter lazyGetter = lazyGetters.get(direction);
         if (lazyGetter == null || !lazyGetter.canRegister()) {
-            lazyGetter = new LazyGetter(client, StarVertex::setVertexAndExternalSiblings);
+            lazyGetter = new LazyGetter(client);
             lazyGetters.put(direction,
                     lazyGetter);
         }

--- a/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarHandler.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarHandler.java
@@ -2,14 +2,10 @@ package org.elasticgremlin.queryhandler.stardoc;
 
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.elasticgremlin.elasticsearch.*;
-import org.elasticgremlin.queryhandler.EdgeHandler;
-import org.elasticgremlin.queryhandler.Predicates;
-import org.elasticgremlin.queryhandler.VertexHandler;
-import org.elasticgremlin.structure.*;
+import org.elasticgremlin.queryhandler.*;
+import org.elasticgremlin.structure.ElasticGraph;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.index.query.BoolFilterBuilder;
-import org.elasticsearch.index.query.FilterBuilders;
-import org.elasticsearch.index.query.OrFilterBuilder;
+import org.elasticsearch.index.query.*;
 import org.elasticsearch.search.SearchHit;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
@@ -58,9 +54,11 @@ public class StarHandler implements VertexHandler, EdgeHandler {
     @Override
     public Iterator<Vertex> vertices(Object[] vertexIds) {
         List<Vertex> vertices = new ArrayList<>();
-        for (Object id : vertexIds)
-            vertices.add(new StarVertex(id, null, null, graph, getLazyGetter(), elasticMutations, getDefaultIndex(), edgeMappings));
-        StarVertex.setVertexAndExternalSiblings(vertices);
+        for (Object id : vertexIds) {
+            StarVertex vertex = new StarVertex(id, null, null, graph, getLazyGetter(), elasticMutations, getDefaultIndex(), edgeMappings);
+            vertex.setSiblings(vertices);
+            vertices.add(vertex);
+        }
         return vertices.iterator();
     }
 
@@ -68,9 +66,7 @@ public class StarHandler implements VertexHandler, EdgeHandler {
     public Iterator<Vertex> vertices(Predicates predicates) {
         BoolFilterBuilder boolFilter = ElasticHelper.createFilterBuilder(predicates.hasContainers);
         return new QueryIterator<>(boolFilter, 0, scrollSize, predicates.limitHigh - predicates.limitLow,
-                client, this::createVertex, StarVertex::setVertexAndExternalSiblings,
-                refresh, getIndices(predicates)
-        );
+                client, this::createVertex, refresh, indices);
     }
 
     @Override
@@ -117,8 +113,7 @@ public class StarHandler implements VertexHandler, EdgeHandler {
         }
 
         QueryIterator<Vertex> vertexSearchQuery = new QueryIterator<>(boolFilter, 0, scrollSize,
-                predicates.limitHigh - predicates.limitLow, client, this::createVertex,
-                StarVertex::setVertexAndExternalSiblings, refresh, getIndices(predicates));
+                predicates.limitHigh - predicates.limitLow, client, this::createVertex, refresh, indices);
 
         Iterator<Edge> edgeResults = new EdgeResults(vertexSearchQuery, direction, edgeLabels);
 
@@ -137,10 +132,6 @@ public class StarHandler implements VertexHandler, EdgeHandler {
     @Override
     public Edge addEdge(Object edgeId, String label, Vertex outV, Vertex inV, Object[] properties) {
         throw new NotImplementedException();
-    }
-
-    protected String[] getIndices(Predicates predicates) {
-        return this.indices;
     }
 
     protected String getDefaultIndex() {
@@ -164,23 +155,26 @@ public class StarHandler implements VertexHandler, EdgeHandler {
         return lazyGetter;
     }
 
-    private Vertex createVertex(SearchHit searchHitFields) {
-        StarVertex vertexWithInnerEdges = new StarVertex(searchHitFields.id(),
-                searchHitFields.getType(), null, graph, null, elasticMutations,
-                searchHitFields.getIndex(), edgeMappings);
-        vertexWithInnerEdges.setFields(searchHitFields.getSource());
-        return vertexWithInnerEdges;
+    private Iterator<Vertex> createVertex(Iterator<SearchHit> hits) {
+        ArrayList<Vertex> vertices = new ArrayList<>();
+        hits.forEachRemaining(hit -> {
+            StarVertex vertex = new StarVertex(hit.id(), hit.getType(), null, graph, null, elasticMutations, hit.getIndex(), edgeMappings);
+            vertex.setFields(hit.getSource());
+            vertex.setSiblings(vertices);
+            vertices.add(vertex);
+        });
+        return vertices.iterator();
     }
 
     private static class EdgeResults implements Iterator<Edge> {
 
         public Iterator<Edge> edges;
 
-        private QueryIterator<Vertex> vertexSearchQuery;
+        private Iterator<Vertex> vertexSearchQuery;
         private Direction direction;
         private String[] edgeLabels;
 
-        public EdgeResults(QueryIterator<Vertex> vertexSearchQuery, Direction direction, String... edgeLabels) {
+        public EdgeResults(Iterator<Vertex> vertexSearchQuery, Direction direction, String... edgeLabels) {
             this.vertexSearchQuery = vertexSearchQuery;
             this.direction = direction;
             this.edgeLabels = edgeLabels;

--- a/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarVertex.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarVertex.java
@@ -13,16 +13,13 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 public class StarVertex extends BaseVertex {
-    private static final int EXTERNAL_VERTEX_BULK = 500;
     private final ElasticMutations elasticMutations;
     private final String indexName;
     private final EdgeMapping[] edgeMappings;
     private LazyGetter lazyGetter;
     private Set<InnerEdge> innerEdges;
 
-    public StarVertex(final Object id, final String label, Object[] keyValues, ElasticGraph graph,
-                      LazyGetter lazyGetter, ElasticMutations elasticMutations, String indexName,
-                      EdgeMapping[] edgeMappings) {
+    public StarVertex(final Object id, final String label, Object[] keyValues, ElasticGraph graph, LazyGetter lazyGetter, ElasticMutations elasticMutations, String indexName, EdgeMapping[] edgeMappings) {
         super(id, label, graph, keyValues);
         this.elasticMutations = elasticMutations;
         this.indexName = indexName;
@@ -44,9 +41,7 @@ public class StarVertex extends BaseVertex {
     protected void innerAddProperty(BaseVertexProperty vertexProperty) {
         try {
             elasticMutations.updateElement(this, indexName, null, false);
-        } catch (ExecutionException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
+        } catch (ExecutionException | InterruptedException e) {
             e.printStackTrace();
         }
     }
@@ -61,9 +56,7 @@ public class StarVertex extends BaseVertex {
     protected void innerRemoveProperty(Property property) {
         try {
             elasticMutations.updateElement(this, indexName, null, false);
-        } catch (ExecutionException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
+        } catch (ExecutionException | InterruptedException e) {
             e.printStackTrace();
         }
     }
@@ -145,42 +138,5 @@ public class StarVertex extends BaseVertex {
                     graph);
             this.innerEdges.add(innerEdge);
         }
-    }
-
-    /**
-     * Set vertices to be siblings of each other,
-     * and do the same to the vertices' external siblings
-     * @param siblings Set the external vertices of each of these vertices to be siblings
-     */
-    public static void setVertexAndExternalSiblings(List<Vertex> siblings) {
-        BaseVertex.setVertexSiblings(siblings);
-
-        // Make sure all vertices are of class StarVertex
-        List<Vertex> vertexSiblings = new ArrayList<>();
-        for (Vertex element : siblings) {
-            if (!StarVertex.class.isAssignableFrom(element.getClass())) continue;
-            vertexSiblings.add(element);
-        }
-
-        List<Vertex> externalVertexSiblings = new ArrayList<>();
-        for (Vertex vertex : vertexSiblings) {
-            // Add all external vertices to list
-            StarVertex starVertex = (StarVertex) vertex;
-            for (InnerEdge innerEdge : starVertex.innerEdges) {
-                switch (innerEdge.getMapping().getDirection()) {
-                    case IN:
-                        externalVertexSiblings.add(innerEdge.outVertex());
-                        break;
-                    case OUT:
-                        externalVertexSiblings.add(innerEdge.inVertex());
-                        break;
-                }
-            }
-            if (externalVertexSiblings.size() >= EXTERNAL_VERTEX_BULK) {
-                BaseVertex.setVertexSiblings(externalVertexSiblings);
-                externalVertexSiblings = new ArrayList<>();
-            }
-        }
-        BaseVertex.setVertexSiblings(externalVertexSiblings);
     }
 }

--- a/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarVertex.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/stardoc/StarVertex.java
@@ -12,7 +12,7 @@ import org.elasticsearch.action.get.MultiGetItemResponse;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
-public class StarVertex extends BaseVertex implements LazyGetter.LazyConsumer {
+public class StarVertex extends BaseVertex {
     private static final int EXTERNAL_VERTEX_BULK = 500;
     private final ElasticMutations elasticMutations;
     private final String indexName;

--- a/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertex.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertex.java
@@ -2,11 +2,9 @@ package org.elasticgremlin.queryhandler.vertexdoc;
 
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.elasticgremlin.elasticsearch.*;
-import org.elasticgremlin.elasticsearch.LazyGetter;
 import org.elasticgremlin.structure.*;
-import org.elasticsearch.action.get.MultiGetItemResponse;
 
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 public class DocVertex extends BaseVertex {
@@ -35,10 +33,7 @@ public class DocVertex extends BaseVertex {
         try {
             elasticMutations.updateElement(this, indexName, null, false);
         }
-        catch (ExecutionException e) {
-            e.printStackTrace();
-        }
-        catch (InterruptedException e) {
+        catch (ExecutionException | InterruptedException e) {
             e.printStackTrace();
         }
     }
@@ -54,10 +49,7 @@ public class DocVertex extends BaseVertex {
         try {
             elasticMutations.updateElement(this, indexName, null, false);
         }
-        catch (ExecutionException e) {
-            e.printStackTrace();
-        }
-        catch (InterruptedException e) {
+        catch (ExecutionException | InterruptedException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertex.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertex.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.get.MultiGetItemResponse;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 
-public class DocVertex extends BaseVertex implements LazyGetter.LazyConsumer {
+public class DocVertex extends BaseVertex {
     private final ElasticMutations elasticMutations;
     private final String indexName;
     private org.elasticgremlin.elasticsearch.LazyGetter lazyGetter;
@@ -71,12 +71,5 @@ public class DocVertex extends BaseVertex implements LazyGetter.LazyConsumer {
     public <V> Iterator<VertexProperty<V>> properties(final String... propertyKeys) {
         if (lazyGetter != null) lazyGetter.execute();
         return super.properties(propertyKeys);
-    }
-
-    @Override
-    public void applyLazyFields(MultiGetItemResponse response) {
-        setLabel(response.getType());
-        response.getResponse().getSource().entrySet().forEach((field) ->
-                addPropertyLocal(field.getKey(), field.getValue()));
     }
 }

--- a/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertexHandler.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertexHandler.java
@@ -78,7 +78,7 @@ public class DocVertexHandler implements VertexHandler {
 
     private LazyGetter getLazyGetter() {
         if (defaultLazyGetter == null || !defaultLazyGetter.canRegister()) {
-            defaultLazyGetter = new LazyGetter(client, BaseVertex::setVertexSiblings);
+            defaultLazyGetter = new LazyGetter(client);
         }
         return defaultLazyGetter;
     }
@@ -86,7 +86,7 @@ public class DocVertexHandler implements VertexHandler {
     private LazyGetter getLazyGetter(Direction direction) {
         LazyGetter lazyGetter = lazyGetters.get(direction);
         if (lazyGetter == null || !lazyGetter.canRegister()) {
-            lazyGetter = new LazyGetter(client, BaseVertex::setVertexSiblings);
+            lazyGetter = new LazyGetter(client);
             lazyGetters.put(direction,
                     lazyGetter);
         }

--- a/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertexHandler.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/vertexdoc/DocVertexHandler.java
@@ -3,6 +3,7 @@ package org.elasticgremlin.queryhandler.vertexdoc;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.elasticgremlin.elasticsearch.*;
 import org.elasticgremlin.elasticsearch.LazyGetter;
+import org.elasticgremlin.elasticsearch.QueryIterator;
 import org.elasticgremlin.queryhandler.edgedoc.DocEdge;
 import org.elasticgremlin.queryhandler.*;
 import org.elasticgremlin.structure.*;
@@ -37,16 +38,17 @@ public class DocVertexHandler implements VertexHandler {
     @Override
     public Iterator<Vertex> vertices() {
         return new QueryIterator<>(FilterBuilders.missingFilter(DocEdge.InId), 0, scrollSize,
-                Integer.MAX_VALUE, client, this::createVertex, BaseVertex::setVertexSiblings, refresh, indexName
-        );
+                Integer.MAX_VALUE, client, this::createVertex, refresh, indexName);
     }
 
     @Override
     public Iterator<Vertex> vertices(Object[] vertexIds) {
         List<Vertex> vertices = new ArrayList<>();
-        for(Object id : vertexIds)
-            vertices.add(new DocVertex(id, null, null, graph, getLazyGetter(), elasticMutations, indexName));
-        vertices.forEach(vertex -> BaseVertex.setVertexSiblings(vertices));
+        for(Object id : vertexIds){
+            DocVertex vertex = new DocVertex(id, null, null, graph, getLazyGetter(), elasticMutations, indexName);
+            vertex.setSiblings(vertices);
+            vertices.add(vertex);
+        }
         return vertices.iterator();
     }
 
@@ -55,7 +57,7 @@ public class DocVertexHandler implements VertexHandler {
         BoolFilterBuilder boolFilter = ElasticHelper.createFilterBuilder(predicates.hasContainers);
         boolFilter.must(FilterBuilders.missingFilter(DocEdge.InId));
         return new QueryIterator<>(boolFilter, 0, scrollSize, predicates.limitHigh - predicates.limitLow,
-                client, this::createVertex, BaseVertex::setVertexSiblings, refresh, indexName
+                client, this::createVertex, refresh, indexName
         );
     }
 
@@ -93,9 +95,14 @@ public class DocVertexHandler implements VertexHandler {
         return lazyGetter;
     }
 
-    private Vertex createVertex(SearchHit hit) {
-        BaseVertex vertex = new DocVertex(hit.id(), hit.getType(), null, graph, null, elasticMutations, indexName);
-        hit.getSource().entrySet().forEach((field) -> vertex.addPropertyLocal(field.getKey(), field.getValue()));
-        return vertex;
+    private Iterator<Vertex> createVertex(Iterator<SearchHit> hits) {
+        ArrayList<Vertex> vertices = new ArrayList<>();
+        hits.forEachRemaining(hit -> {
+            BaseVertex vertex = new DocVertex(hit.id(), hit.getType(), null, graph, null, elasticMutations, indexName);
+            vertex.setSiblings(vertices);
+            hit.getSource().entrySet().forEach((field) -> vertex.addPropertyLocal(field.getKey(), field.getValue()));
+            vertices.add(vertex);
+        });
+        return vertices.iterator();
     }
 }

--- a/src/main/java/org/elasticgremlin/queryhandler/virtualvertex/VirtualVertexHandler.java
+++ b/src/main/java/org/elasticgremlin/queryhandler/virtualvertex/VirtualVertexHandler.java
@@ -31,7 +31,6 @@ public class VirtualVertexHandler implements VertexHandler {
         ArrayList<Vertex> vertices = new ArrayList<>();
         for(Object id : vertexIds)
             vertices.add(new VirtualVertex(id, label, graph, null));
-        BaseVertex.setVertexSiblings(vertices);
         return vertices.iterator();
     }
 

--- a/src/main/java/org/elasticgremlin/structure/BaseEdge.java
+++ b/src/main/java/org/elasticgremlin/structure/BaseEdge.java
@@ -3,9 +3,7 @@ package org.elasticgremlin.structure;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
+import java.util.*;
 
 public abstract class BaseEdge extends BaseElement implements Edge {
 
@@ -18,7 +16,7 @@ public abstract class BaseEdge extends BaseElement implements Edge {
     }
 
     @Override
-    public <V> Property<V> createProperty(String key, V value) {
+    public  Property createProperty(String key, Object value) {
         return new BaseProperty<>(this, key, value);
     }
 

--- a/src/main/java/org/elasticgremlin/structure/BaseElement.java
+++ b/src/main/java/org/elasticgremlin/structure/BaseElement.java
@@ -30,11 +30,11 @@ public abstract class BaseElement implements Element{
 
     }
 
-    public <V> Property<V> addPropertyLocal(String key, V value) {
+    public Property addPropertyLocal(String key, Object value) {
         checkRemoved();
         if (shouldAddProperty(key)) {
             ElementHelper.validateProperty(key, value);
-            Property<V> property = createProperty(key, value);
+            Property property = createProperty(key, value);
             properties.put(key, property);
             return property;
         }
@@ -95,7 +95,7 @@ public abstract class BaseElement implements Element{
 
     protected abstract void innerRemoveProperty(Property property);
 
-    protected abstract <V> Property<V> createProperty(String key, V value);
+    protected abstract Property createProperty(String key, Object value);
 
     protected boolean shouldAddProperty(String key) {
         return !key.equals("label") && !key.equals("id");

--- a/src/main/java/org/elasticgremlin/structure/BaseVertex.java
+++ b/src/main/java/org/elasticgremlin/structure/BaseVertex.java
@@ -3,6 +3,7 @@ package org.elasticgremlin.structure;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.util.*;
 import org.elasticgremlin.queryhandler.Predicates;
+import org.elasticsearch.action.get.MultiGetItemResponse;
 
 import java.util.*;
 
@@ -64,6 +65,12 @@ public abstract class BaseVertex extends BaseElement implements Vertex {
     public void addQueriedEdges(List<Edge> edges, Direction direction, String[] edgeLabels, Predicates predicates) {
         EdgeQueryInfo queryInfo = new EdgeQueryInfo(direction, edgeLabels, predicates);
         queriedEdges.put(queryInfo, edges);
+    }
+
+    public void applyLazyFields(MultiGetItemResponse response) {
+        setLabel(response.getType());
+        response.getResponse().getSource().entrySet().forEach((field) ->
+                addPropertyLocal(field.getKey(), field.getValue()));
     }
 
     public static Vertex vertexToVertex(Vertex originalVertex, Edge edge, Direction direction) {

--- a/src/main/java/org/elasticgremlin/structure/BaseVertex.java
+++ b/src/main/java/org/elasticgremlin/structure/BaseVertex.java
@@ -93,14 +93,6 @@ public abstract class BaseVertex extends BaseElement implements Vertex {
         }
     }
 
-    public static void setVertexSiblings(List<Vertex> siblings) {
-        for (Vertex vertex : siblings) {
-            if (!BaseVertex.class.isAssignableFrom(vertex.getClass())) {
-                return;
-            }
-            ((BaseVertex)vertex).setSiblings(siblings);
-        }
-    }
 
     @Override
     public <V> VertexProperty<V> property(String key, V value) {
@@ -135,7 +127,7 @@ public abstract class BaseVertex extends BaseElement implements Vertex {
     @Override
     public void remove() {
         super.remove();
-        edges(Direction.BOTH).forEachRemaining(edge -> edge.remove());
+        edges(Direction.BOTH).forEachRemaining(Element::remove);
     }
 
     @Override

--- a/src/main/java/org/elasticgremlin/structure/ElasticGraph.java
+++ b/src/main/java/org/elasticgremlin/structure/ElasticGraph.java
@@ -5,35 +5,35 @@ import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.util.*;
-import org.elasticgremlin.queryhandler.QueryHandler;
 import org.elasticgremlin.process.optimize.ElasticOptimizationStrategy;
-import org.elasticgremlin.queryhandler.SimpleQueryHandler;
+import org.elasticgremlin.queryhandler.*;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.FeatureSupportTest$VertexPropertyFunctionalityTest", method = "shouldSupportNumericIdsIfNumericIdsAreGeneratedFromTheGraph",
         reason = "need to handle ids in VertexProperties")
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.GraphTest", method = "shouldHaveExceptionConsistencyWhenFindVertexByIdThatIsNonExistentViaIterator",
         reason = "We don't throw an exception when the vertexdoc doesn't exist, because we support \"virtual vertices\"")
-@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadWriteClassicToGryo",
+@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest$GraphSONTest", method = "shouldReadLegacyGraphSON",
+        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
+@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest$GraphMLTest", method = "shouldReadGraphML",
+        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
+@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest$GraphMLTest", method = "shouldReadGraphMLAnAllSupportedDataTypes",
+        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
+@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest$GraphMLTest", method = "shouldReadGraphMLUnorderedElements",
+        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
+/*
+@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadWriteClassic",
         reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldMigrateGraphWithFloat",
         reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadWriteClassicToGraphMLToFileWithHelpers",
         reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
-@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadGraphMLAnAllSupportedDataTypes",
-        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadWriteVertexWithBOTHEdgesToGraphSONWithTypes",
         reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
-@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadGraphML",
-        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
-@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadLegacyGraphSON",
-        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
-@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.structure.io.IoTest", method = "shouldReadGraphMLUnorderedElements",
-        reason = "https://github.com/rmagen/elastic-gremlin/issues/52")
+*/
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest", method = "g_V_repeatXoutX_timesX8X_count",
         reason = "Takes too much time. https://github.com/rmagen/elastic-gremlin/issues/21")
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest", method = "g_V_repeatXoutX_timesX3X_count",


### PR DESCRIPTION
Now accepts BaseVertex instead of LazyConsumer, applies siblings on registration.
Fixes #57 
